### PR TITLE
Add admin role checks

### DIFF
--- a/manage_developers_projects.php
+++ b/manage_developers_projects.php
@@ -1,4 +1,8 @@
 <?php
+session_start();
+if (!isset($_SESSION['role']) || $_SESSION['role'] !== 'admin') {
+    die('Access denied.');
+}
 // manage_developers_projects.php
 
 require_once 'db_connection.php';

--- a/process_upload.php
+++ b/process_upload.php
@@ -1,6 +1,9 @@
 <?php
 // process_upload.php
 session_start();
+if (!isset($_SESSION['role']) || $_SESSION['role'] !== 'admin') {
+    die('Access denied.');
+}
 
 ini_set('display_errors', 1);
 error_reporting(E_ALL);


### PR DESCRIPTION
## Summary
- restrict access to developer and project management page
- guard the upload processing script from unauthorized usage

## Testing
- `php -l manage_developers_projects.php` *(fails: command not found)*
- `php -l process_upload.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6849837714d4832280623aa55a25ecbe