### PR TITLE
Add centralized role checking helper

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -1,0 +1,23 @@
+<?php
+// auth.php
+
+function require_role(array $allowedRoles)
+{
+    if (session_status() === PHP_SESSION_NONE) {
+        session_start();
+    }
+    $role = $_SESSION['role'] ?? null;
+    if (!$role || !in_array($role, $allowedRoles, true)) {
+        header('Location: index.php');
+        exit();
+    }
+}
+
+function has_role(array $allowedRoles): bool
+{
+    if (session_status() === PHP_SESSION_NONE) {
+        session_start();
+    }
+    $role = $_SESSION['role'] ?? null;
+    return $role && in_array($role, $allowedRoles, true);
+}

--- a/manage_developers_projects.php
+++ b/manage_developers_projects.php
@@ -1,8 +1,6 @@
 <?php
-session_start();
-if (!isset($_SESSION['role']) || $_SESSION['role'] !== 'admin') {
-    die('Access denied.');
-}
+require_once 'auth.php';
+require_role(['admin']);
 // manage_developers_projects.php
 
 require_once 'db_connection.php';

--- a/manage_users.php
+++ b/manage_users.php
@@ -1,9 +1,7 @@
 <?php
 // manage_users.php
-session_start();
-if (!isset($_SESSION['user_id']) || $_SESSION['role'] !== 'admin') {
-    die("Access denied. Admins only.");
-}
+require_once 'auth.php';
+require_role(['admin']);
 
 require_once 'db_connection.php';
 require_once 'csrf.php';

--- a/navbar.php
+++ b/navbar.php
@@ -1,10 +1,6 @@
 <?php
 // navbar.php
-if (session_status() == PHP_SESSION_NONE) {
-    session_start();
-}
-
-$role = $_SESSION['role'] ?? '';
+require_once 'auth.php';
 ?>
 
 <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
@@ -20,7 +16,7 @@ $role = $_SESSION['role'] ?? '';
                 <li class="nav-item"><a class="nav-link" href="manage_developers_projects.php">Manage Projects</a></li>
                 <li class="nav-item"><a class="nav-link" href="display_apartments.php">View By Project</a></li>
                 <li class="nav-item"><a class="nav-link" href="all_apartments.php">Filter All Apartments</a></li>
-                <?php if ($role === 'admin') { ?>
+                <?php if (has_role(['admin'])) { ?>
                     <li class="nav-item"><a class="nav-link" href="register_user.php">Register User</a></li>
                 <?php } ?>
                 <li class="nav-item"><a class="nav-link" href="logout.php">Logout</a></li>

--- a/process_upload.php
+++ b/process_upload.php
@@ -1,9 +1,7 @@
 <?php
 // process_upload.php
-session_start();
-if (!isset($_SESSION['role']) || $_SESSION['role'] !== 'admin') {
-    die('Access denied.');
-}
+require_once 'auth.php';
+require_role(['admin']);
 
 ini_set('display_errors', 1);
 error_reporting(E_ALL);

--- a/register_user.php
+++ b/register_user.php
@@ -1,10 +1,7 @@
 <?php
 // register_user.php
-session_start();
-
-if (!isset($_SESSION['role']) || $_SESSION['role'] !== 'admin') {
-    die("Access denied. Admins only.");
-}
+require_once 'auth.php';
+require_role(['admin']);
 
 require_once 'db_connection.php';
 require_once 'csrf.php';


### PR DESCRIPTION
## Summary
- add `require_role()` helper in `auth.php`
- protect admin pages via the new helper
- update `navbar.php` to check roles using helper

## Testing
- `php -l auth.php` *(fails: command not found)*
- `composer install` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684a6f2018748322820da7819b4181ae