### PR TITLE
Unify role handling across user management scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,11 @@ php create_admin.php
 ```
 
 After logging in with this account, you can manage users from the dashboard.
+
+## Roles
+
+The application defines three roles:
+
+- **viewer** – can view listings.
+- **editor** – can upload and edit apartment data.
+- **admin** – full access including user management.

--- a/create_admin.php
+++ b/create_admin.php
@@ -1,12 +1,13 @@
 <?php
 // create_admin.php — Run this once to insert the first admin user
 require_once 'db_connection.php';
+require_once 'roles.php';
 
 // Change these as needed
 $name = 'Admin';
 $email = ''; // Enter admin email before running
 $password_plain = ''; // Enter admin password before running
-$role = 'admin';
+$role = ROLE_ADMIN;
 $id = uniqid();
 
 // Hash the password

--- a/manage_developers_projects.php
+++ b/manage_developers_projects.php
@@ -1,6 +1,7 @@
 <?php
 require_once 'auth.php';
-require_role(['admin']);
+require_once 'roles.php';
+require_role([ROLE_ADMIN]);
 // manage_developers_projects.php
 
 require_once 'db_connection.php';

--- a/manage_users.php
+++ b/manage_users.php
@@ -1,7 +1,8 @@
 <?php
 // manage_users.php
 require_once 'auth.php';
-require_role(['admin']);
+require_once 'roles.php';
+require_role([ROLE_ADMIN]);
 
 require_once 'db_connection.php';
 require_once 'csrf.php';
@@ -16,6 +17,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['action']) && $_POST['
     $email = $_POST['email'];
     $password = password_hash($_POST['password'], PASSWORD_DEFAULT);
     $role = $_POST['role'];
+    if (!in_array($role, ROLES, true)) {
+        die('Invalid role');
+    }
 
     $stmt = $conn->prepare("INSERT INTO users (name, email, password_hash, role) VALUES (?, ?, ?, ?)");
     $stmt->bind_param('ssss', $name, $email, $password, $role);
@@ -41,6 +45,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['action']) && $_POST['
     }
     $id = intval($_POST['user_id']);
     $role = $_POST['role'];
+    if (!in_array($role, ROLES, true)) {
+        die('Invalid role');
+    }
 
     if (!empty($_POST['new_password'])) {
         $new_password = password_hash($_POST['new_password'], PASSWORD_DEFAULT);
@@ -99,8 +106,9 @@ $users = $stmt->get_result();
         <div class="col-md-3"><input type="password" name="password" class="form-control" placeholder="Password" required></div>
         <div class="col-md-2">
             <select name="role" class="form-control">
-                <option value="user">User</option>
-                <option value="admin">Admin</option>
+                <option value="<?= ROLE_VIEWER ?>">Viewer</option>
+                <option value="<?= ROLE_EDITOR ?>">Editor</option>
+                <option value="<?= ROLE_ADMIN ?>">Admin</option>
             </select>
         </div>
         <div class="col-md-1"><button type="submit" class="btn btn-primary">Add</button></div>
@@ -130,8 +138,9 @@ $users = $stmt->get_result();
                             <input type="hidden" name="user_id" value="<?= $user['id'] ?>">
                             <div class="col-md-5">
                                 <select name="role" class="form-control">
-                                    <option value="user" <?= $user['role'] === 'user' ? 'selected' : '' ?>>User</option>
-                                    <option value="admin" <?= $user['role'] === 'admin' ? 'selected' : '' ?>>Admin</option>
+                                    <option value="<?= ROLE_VIEWER ?>" <?= $user['role'] === ROLE_VIEWER ? 'selected' : '' ?>>Viewer</option>
+                                    <option value="<?= ROLE_EDITOR ?>" <?= $user['role'] === ROLE_EDITOR ? 'selected' : '' ?>>Editor</option>
+                                    <option value="<?= ROLE_ADMIN ?>" <?= $user['role'] === ROLE_ADMIN ? 'selected' : '' ?>>Admin</option>
                                 </select>
                             </div>
                             <div class="col-md-5"><input type="password" name="new_password" class="form-control" placeholder="New Password"></div>

--- a/navbar.php
+++ b/navbar.php
@@ -1,6 +1,7 @@
 <?php
 // navbar.php
 require_once 'auth.php';
+require_once 'roles.php';
 ?>
 
 <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
@@ -16,7 +17,7 @@ require_once 'auth.php';
                 <li class="nav-item"><a class="nav-link" href="manage_developers_projects.php">Manage Projects</a></li>
                 <li class="nav-item"><a class="nav-link" href="display_apartments.php">View By Project</a></li>
                 <li class="nav-item"><a class="nav-link" href="all_apartments.php">Filter All Apartments</a></li>
-                <?php if (has_role(['admin'])) { ?>
+                <?php if (has_role([ROLE_ADMIN])) { ?>
                     <li class="nav-item"><a class="nav-link" href="register_user.php">Register User</a></li>
                 <?php } ?>
                 <li class="nav-item"><a class="nav-link" href="logout.php">Logout</a></li>

--- a/process_upload.php
+++ b/process_upload.php
@@ -1,7 +1,8 @@
 <?php
 // process_upload.php
 require_once 'auth.php';
-require_role(['admin']);
+require_once 'roles.php';
+require_role([ROLE_ADMIN]);
 
 ini_set('display_errors', 1);
 error_reporting(E_ALL);

--- a/register_user.php
+++ b/register_user.php
@@ -1,7 +1,8 @@
 <?php
 // register_user.php
 require_once 'auth.php';
-require_role(['admin']);
+require_once 'roles.php';
+require_role([ROLE_ADMIN]);
 
 require_once 'db_connection.php';
 require_once 'csrf.php';
@@ -14,6 +15,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $email = $conn->real_escape_string($_POST['email']);
     $password = password_hash($_POST['password'], PASSWORD_DEFAULT);
     $role = $conn->real_escape_string($_POST['role']);
+    if (!in_array($role, ROLES, true)) {
+        die('Invalid role');
+    }
     $id = uniqid();
 
     $check = $conn->query("SELECT id FROM users WHERE email = '$email'");
@@ -78,9 +82,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             <div class="mb-3">
                 <label class="form-label">Role:</label>
                 <select name="role" class="form-select" required>
-                    <option value="viewer">Viewer</option>
-                    <option value="editor">Editor</option>
-                    <option value="admin">Admin</option>
+                    <option value="<?= ROLE_VIEWER ?>">Viewer</option>
+                    <option value="<?= ROLE_EDITOR ?>">Editor</option>
+                    <option value="<?= ROLE_ADMIN ?>">Admin</option>
                 </select>
             </div>
             <button type="submit" class="btn btn-primary">Register User</button>

--- a/roles.php
+++ b/roles.php
@@ -1,0 +1,18 @@
+<?php
+// roles.php
+
+/**
+ * Application roles
+ */
+const ROLE_VIEWER = 'viewer';
+const ROLE_EDITOR = 'editor';
+const ROLE_ADMIN  = 'admin';
+
+/**
+ * List of all roles for convenience
+ */
+const ROLES = [
+    ROLE_VIEWER,
+    ROLE_EDITOR,
+    ROLE_ADMIN,
+];


### PR DESCRIPTION
## Summary
- centralize user roles in new `roles.php`
- require and use the role constants everywhere
- update user management pages and seed script to validate roles
- document available roles in the README

## Testing
- `php` and `composer` were not available, so no tests were run

------
https://chatgpt.com/codex/tasks/task_b_684a7337ae6c8322aae88312292acae8